### PR TITLE
Review von "Gendergerechte Sprache"

### DIFF
--- a/docs/writing/gender.rst
+++ b/docs/writing/gender.rst
@@ -11,8 +11,8 @@ Direkte Anrede
     zu verwenden, :abbr:`s.a. (siehe auch)` :ref:`Aktiv und Passiv
     <aktiv-und-passiv>`.
 
-    Auch das Gerundiv, wie :abbr:`z.B. (zum Beispiel)` *Studierende*, können wir
-    damit vermeiden.
+    Auch substantivierte Partizipien, wie :abbr:`z.B. (zum Beispiel)`
+    *Studierende*, können wir damit vermeiden.
 
 Direkte persönliche Anrede
     Sofern wir die Geschlechteridentität nicht kennen, wählen wir zunächst eine

--- a/docs/writing/gender.rst
+++ b/docs/writing/gender.rst
@@ -11,8 +11,8 @@ Direkte Anrede
     zu verwenden, :abbr:`s.a. (siehe auch)` :ref:`Aktiv und Passiv
     <aktiv-und-passiv>`.
 
-    Auch das passive Gerundiv, wie :abbr:`z.B. (zum Beispiel)` *Studierende*
-    können wir damit vermeiden.
+    Auch das Gerundiv, wie :abbr:`z.B. (zum Beispiel)` *Studierende*, können wir
+    damit vermeiden.
 
 Direkte persönliche Anrede
     Sofern wir die Geschlechteridentität nicht kennen, wählen wir zunächst eine


### PR DESCRIPTION
Das liest sich schon sehr gut, mein PR hat nur eine kleine Korrektur: "Passives Gerundiv" habe ich für "Studierende" etc. noch nie gelesen, die Literatur sehe ich hauptsächlich von substantivierten Partizipien sprechen. Ein Gerundiv ist auch, soweit ich das verstehe, eher ein Adjektiv.

Der Text legt den Fokus gefühlt auf Kürze und Klarheit und besitzt dafür kaum Hintergrundinformationen über das "Warum". Ich vermute, das ist eine absichtlich getroffene Entscheidung, um die Prägnanz nicht zu verlieren. Diese Entscheidung kann ich nachvollziehen und unterstütze sie, sofern ausreichende Vorbildung bei der Zielgruppe vorausgesetzt werden kann. Wenn ich mich mit dem Thema weniger gut auskennen würde, käme ich mir vielleicht ein bisschen verloren vor und würde mir z.B. ein bis zwei Links zu einer Einführung in "warum der ganze Quatsch" wünschen. (Leider habe ich keine parat.)

Einen Ergänzungsvorschlag habe ich allerdings noch, weiß aber nicht genau, wo ich ihn einfügen könnte oder wie ich ihn formulieren sollte: Bei alledem sollte man auch immer darauf achten, nicht durch unreflektiertes Befolgen der Richtlinien das Ziel zu verfehlen. Beispielsweise habe ich letztens die Formulierung _"**Der** nächste freie Mitarbeitende ist für Sie reserviert"_ gelesen. Das ist natürlich Unsinn. Gerade diese substantivierten Partizipien funktionieren häufig nur im Plural.